### PR TITLE
Changes `existing_row_resource` to find an existing resource based on…

### DIFF
--- a/lib/active_admin_csv_import/dsl.rb
+++ b/lib/active_admin_csv_import/dsl.rb
@@ -94,7 +94,7 @@ module ActiveAdminCsvImport
           value = params[lookup_column]
           return unless value.present?
 
-          active_admin_config.resource_class.send(finder_method, value)
+          scoped_collection.send(finder_method, value)
         end
       end
     end


### PR DESCRIPTION
… the current scoped collection.

By sending the finder method direct to the resource class, it bypasses any scopes put in place by the admin resource (i.e. use of a non-optional `belongs_to :parent` would still allow updating of children globally, not those belonging to the current parent resource)

Fixes #16
