### PR TITLE
NoMethodError with_indifferent_access on Rails 5

### DIFF
--- a/lib/active_admin_csv_import/dsl.rb
+++ b/lib/active_admin_csv_import/dsl.rb
@@ -49,7 +49,7 @@ module ActiveAdminCsvImport
         @failures = []
 
         csv_resource_params.values.each do |row_params|
-          row_params = row_params.with_indifferent_access
+          row_params = row_params.to_h.with_indifferent_access
           row_number = row_params.delete('_row')
 
           resource = existing_row_resource(options[:import_unique_key], row_params)


### PR DESCRIPTION
Since Rails 5 parameters aren't implemented as hashes anymore and therefore don't support `with_indifferent_access`.
They support `to_h` though.

More details https://blog.bigbinary.com/2016/07/25/parameters-no-longer-inherit-from-hash-with-indifferent-access-in-rails-5.html